### PR TITLE
:tada: Add support for Challengermode demos

### DIFF
--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -154,6 +154,10 @@ func GetDemoSource(demo *Demo) constants.DemoSource {
 		return constants.DemoSourceCEVO
 	}
 
+	if strings.Contains(serverName, "challengermode") {
+		return constants.DemoSourceChallengermode
+	}
+
 	if strings.Contains(serverName, "esl") {
 		return constants.DemoSourceESL
 	}

--- a/js/src/constants.ts
+++ b/js/src/constants.ts
@@ -12,6 +12,7 @@ export const DemoSource = {
   Popflash: 'popflash',
   FaceIt: 'faceit',
   Cevo: 'cevo',
+  Challengermode: 'challengermode',
   Esl: 'esl',
   Esea: 'esea',
   Esportal: 'esportal',

--- a/pkg/api/analyzer.go
+++ b/pkg/api/analyzer.go
@@ -176,6 +176,8 @@ func analyzeDemo(demoPath string, options AnalyzeDemoOptions) (*Match, error) {
 		createEseaAnalyzer(analyzer)
 	case constants.DemoSourceEbot:
 		createEbotAnalyzer(analyzer)
+	case constants.DemoSourceChallengermode:
+		createChallengermodeAnalyzer(analyzer)
 	case constants.DemoSourceEsportal:
 		return nil, errors.New("esportal demos are not supported (EsportalNotSupported)")
 	case constants.DemoSourceCEVO:

--- a/pkg/api/challengermode.go
+++ b/pkg/api/challengermode.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"github.com/akiver/cs-demo-analyzer/pkg/api/constants"
+	events "github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/events"
+)
+
+func createChallengermodeAnalyzer(analyzer *Analyzer) {
+	parser := analyzer.parser
+	match := analyzer.match
+	match.gameModeStr = constants.GameModeStrCompetitive
+	matchStarted := false
+
+	analyzer.matchStarted = func() bool {
+		return matchStarted
+	}
+
+	parser.RegisterEventHandler(func(event events.MatchStartedChanged) {
+		if !event.OldIsStarted && event.NewIsStarted && !analyzer.isKnifeRound() {
+			matchStarted = true
+
+			for _, participant := range parser.GameState().Participants().Playing() {
+				for _, player := range match.PlayersBySteamID {
+					if player.SteamID64 == participant.SteamID64 {
+						var team *Team
+						if *match.TeamA.CurrentSide == participant.Team {
+							team = match.TeamA
+						} else {
+							team = match.TeamB
+						}
+						player.Team = team
+					}
+				}
+			}
+
+			currentRound := analyzer.currentRound
+			currentRound.StartFrame = parser.CurrentFrame()
+			currentRound.StartTick = analyzer.currentTick()
+			currentRound.TeamASide = *match.TeamA.CurrentSide
+			currentRound.TeamBSide = *match.TeamB.CurrentSide
+			analyzer.updateTeamNames()
+			analyzer.createPlayersEconomies()
+		}
+	})
+
+	parser.RegisterEventHandler(func(event events.RoundFreezetimeChanged) {
+		if !analyzer.matchStarted() {
+			return
+		}
+
+		// It may not be accurate to create players economy on round start because it's possible to buy
+		// a few ticks before the round start event and so may results in incorrect values.
+		// Do it when the freeze time starts, it's updated just before round start events.
+		if event.NewIsFreezetime {
+			analyzer.createPlayersEconomies()
+		} else {
+			analyzer.currentRound.FreezeTimeEndTick = analyzer.currentTick()
+			analyzer.currentRound.FreezeTimeEndFrame = parser.CurrentFrame()
+			analyzer.lastFreezeTimeEndTick = analyzer.currentTick()
+		}
+	})
+
+	parser.RegisterEventHandler(func(event events.RoundStart) {
+		if !analyzer.matchStarted() {
+			return
+		}
+
+		// No Rounds have been added yet, don't create a new one in this case, it's still the first round.
+		if len(match.Rounds) == 0 {
+			return
+		}
+
+		analyzer.createRound()
+	})
+
+	parser.RegisterEventHandler(func(event events.RoundEndOfficial) {
+		if !analyzer.matchStarted() {
+			return
+		}
+
+		match.Rounds = append(match.Rounds, analyzer.currentRound)
+	})
+
+	parser.RegisterEventHandler(func(event events.AnnouncementWinPanelMatch) {
+		analyzer.updatePlayersScores()
+		matchStarted = false
+	})
+
+	analyzer.postProcess = func() {
+		currentRound := analyzer.currentRound
+		if len(match.Rounds) < currentRound.Number {
+			match.Rounds = append(match.Rounds, currentRound)
+		}
+	}
+}

--- a/pkg/api/constants/demo_source.go
+++ b/pkg/api/constants/demo_source.go
@@ -7,17 +7,18 @@ func (source DemoSource) String() string {
 }
 
 const (
-	DemoSourceUnknown    DemoSource = "unknown"
-	DemoSourceValve      DemoSource = "valve"
-	DemoSourceESEA       DemoSource = "esea"
-	DemoSourceFaceIt     DemoSource = "faceit"
-	DemoSourceEbot       DemoSource = "ebot"
-	DemoSourceCEVO       DemoSource = "cevo"
-	DemoSourceESL        DemoSource = "esl"
-	DemoSourcePopFlash   DemoSource = "popflash"
-	DemoSourceEsportal   DemoSource = "esportal"
-	DemoSourceFastcup    DemoSource = "fastcup"
-	DemoSourceGamersclub DemoSource = "gamersclub"
+	DemoSourceUnknown        DemoSource = "unknown"
+	DemoSourceValve          DemoSource = "valve"
+	DemoSourceESEA           DemoSource = "esea"
+	DemoSourceFaceIt         DemoSource = "faceit"
+	DemoSourceEbot           DemoSource = "ebot"
+	DemoSourceCEVO           DemoSource = "cevo"
+	DemoSourceChallengermode DemoSource = "challengermode"
+	DemoSourceESL            DemoSource = "esl"
+	DemoSourcePopFlash       DemoSource = "popflash"
+	DemoSourceEsportal       DemoSource = "esportal"
+	DemoSourceFastcup        DemoSource = "fastcup"
+	DemoSourceGamersclub     DemoSource = "gamersclub"
 )
 
 var SupportedDemoSources = []DemoSource{


### PR DESCRIPTION
Added a DemoSource for Challengermode. 

The FaceItParser seemed to work well both for CS:GO and CS:2. 
I created a new analyzer for future differing behaviour (uneccessary?)

I can supply some more demos to test with if needed. 

Regards, 