### PR TITLE
fix: use CS2 player info slot for user id

### DIFF
--- a/pkg/api/analyzer.go
+++ b/pkg/api/analyzer.go
@@ -57,7 +57,10 @@ type Analyzer struct {
 	// Because several hostages can be untied at the same time, we keep track of players that started untying hostages
 	// to detect which player is untying an hostage in case of consecutive events.
 	playersUntyingAnHostage map[uint64]int
-	chickenEntities         []st.Entity
+	// CS2's game-event user IDs can collide after demoinfocs masks them to their low byte. The userinfo stringtable
+	// index is the stable player slot needed by commands such as spec_player.
+	playerSlotBySteamID64 map[uint64]int
+	chickenEntities       []st.Entity
 }
 
 type AnalyzeDemoOptions struct {
@@ -121,6 +124,7 @@ func analyzeDemo(demoPath string, options AnalyzeDemoOptions) (*Match, error) {
 		bombPlantPosition:         r3.Vector{},
 		lastGrenadeThrownByPlayer: make(map[uint64]*Shot),
 		playersUntyingAnHostage:   make(map[uint64]int),
+		playerSlotBySteamID64:     make(map[uint64]int),
 		postProcess:               defaultPostProcess,
 	}
 
@@ -560,6 +564,14 @@ func (analyzer *Analyzer) registerCommonHandlers(includePositions bool) {
 
 	parser.RegisterEventHandler(func(event events.POVRecordingPlayerDetected) {
 		match.Type = "POV"
+	})
+
+	parser.RegisterEventHandler(func(event events.PlayerInfo) {
+		if !analyzer.isSource2 || event.Info.XUID == 0 {
+			return
+		}
+
+		analyzer.playerSlotBySteamID64[event.Info.XUID] = event.Index
 	})
 
 	parser.RegisterEventHandler(func(event events.PlayerTeamChange) {

--- a/pkg/api/player.go
+++ b/pkg/api/player.go
@@ -787,6 +787,21 @@ func (player *Player) reset() {
 	}
 }
 
+func getPlayerUserID(analyzer *Analyzer, player common.Player) int {
+	if analyzer.isSource2 {
+		userID, exists := analyzer.playerSlotBySteamID64[player.SteamID64]
+		if exists {
+			return userID
+		}
+	}
+
+	if player.UserID <= math.MaxUint16 {
+		return player.UserID & 0xff
+	}
+
+	return 0
+}
+
 func NewPlayer(analyzer *Analyzer, currentTeam common.Team, player common.Player) *Player {
 	var team *Team
 	if *analyzer.match.TeamA.CurrentSide == currentTeam {
@@ -797,15 +812,10 @@ func NewPlayer(analyzer *Analyzer, currentTeam common.Team, player common.Player
 
 	color, _ := player.ColorOrErr()
 	rank := player.Rank()
-	userID := 0
-	if player.UserID <= math.MaxUint16 {
-		userID = player.UserID & 0xff
-	}
-
 	newPlayer := &Player{
 		match:              analyzer.match,
 		SteamID64:          player.SteamID64,
-		UserID:             userID,
+		UserID:             getPlayerUserID(analyzer, player),
 		Name:               strings.ReplaceUTF8ByteSequences(player.Name),
 		Team:               team,
 		CrosshairShareCode: player.CrosshairCode(),

--- a/pkg/api/player_test.go
+++ b/pkg/api/player_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/common"
+)
+
+func TestGetPlayerUserIDUsesSource2PlayerInfoSlot(t *testing.T) {
+	analyzer := &Analyzer{
+		isSource2: true,
+		playerSlotBySteamID64: map[uint64]int{
+			76561198336883042: 9,
+		},
+	}
+	player := common.Player{
+		SteamID64: 76561198336883042,
+		UserID:    0,
+	}
+
+	userID := getPlayerUserID(analyzer, player)
+	if userID != 9 {
+		t.Fatalf("Expected Source2 PlayerInfo slot 9, got %d", userID)
+	}
+}
+
+func TestGetPlayerUserIDFallsBackToMaskedUserID(t *testing.T) {
+	analyzer := &Analyzer{
+		isSource2:             true,
+		playerSlotBySteamID64: make(map[uint64]int),
+	}
+	player := common.Player{
+		SteamID64: 76561198336883042,
+		UserID:    0xff09,
+	}
+
+	userID := getPlayerUserID(analyzer, player)
+	if userID != 9 {
+		t.Fatalf("Expected masked user ID 9, got %d", userID)
+	}
+}


### PR DESCRIPTION
## Problem

CS2 player slots exported by the analyzer can be incorrect when relying on `common.Player.UserID & 0xff`.

I hit this with a Valve CS2 Ancient demo where two players were exported with the same `userId` / slot:

- `HaO...`: `userId = 0`, slot `1`
- `real`: `userId = 0`, slot `1`
- slot `10` was missing entirely

This caused downstream tools such as CS Demo Manager video generation to focus the wrong POV with `spec_player`, even though SteamID-based data such as kills/deathnotices was correct.

## Cause

For CS2 demos, demoinfocs emits `events.PlayerInfo` from the userinfo stringtable. That event includes `Index`, which is the stable player slot needed for slot-based spectator commands.

The analyzer was instead deriving the exported user ID from `common.Player.UserID & 0xff`. In this demo, that produced a low-byte collision, so two players resolved to the same exported slot.

## Fix

This change records CS2 `events.PlayerInfo.Index` by SteamID and uses that value when creating analyzer players.

If the PlayerInfo mapping is unavailable, the analyzer falls back to the previous masked `UserID` behavior to avoid regressing demos that currently rely on it.

## Verification

I tested this against three Valve CS2 demos from the same day:

- Ancient: previously broken, now exports unique slots `1..10`; target player `real` is correctly slot `10`
- Mirage: unchanged, still exports unique slots `1..10`
- Dust2: unchanged, still exports unique slots `1..10`

Also ran:

```bash
go test ./cmd/... ./internal/... ./pkg/...
```

## Note

This issue was debugged with help from Codex, and this patch was created as the solution I found while investigating a downstream CS Demo Manager POV bug. No worries if this is not the direction maintainers want to take or if the PR is not merged; I mainly wanted to share the concrete repro/root cause and a small proposed fix.